### PR TITLE
Add all pinentry args to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+Elephantine
+---
+
+A pinentry program that allows shelling out to an arbitrary program to get user input.
+We aim to implement enough of the Assuan protocol to support this use case.
+
+# Usage
+```
+Implements the pinentry protocol and uses walker for PIN input
+
+Usage: elephantine [OPTIONS]
+
+Options:
+  -d, --debug...                       The debug level [env: ELEPHANTINE_DEBUG=]
+      --config-file <FILE>             Path to the configuration file [env: ELEPHANTINE_CONFIG_FILE=] [default: /home/narthana/.config/elephantine/elephantine.toml]
+  -D, --display [<DISPLAY>]            The X display to use for the dialog [env: PINENTRY_DISPLAY=]
+  -T, --ttyname [<FILE>]               The tty terminal node name [env: TTYNAME=]
+  -N, --ttytype [<NAME>]               [env: TTYTYPE=]
+  -C, --lc-ctype [<STRING>]            The `LC_CTYPE` locale category [env: LC_CTYPE=]
+  -M, --lc-messages [<STRING>]         The `LC_MESSAGES` value [env: LC_MESSAGES=]
+  -o, --timeout [<SECS>]               Timeout in seconds for requests that show dialogs to the user. E.g. GETPIN, CONFIRM, etc [env: ELEPHANTINE_TIMEOUT=] [default: 300]
+  -g, --no-local-grab <NO_LOCAL_GRAB>  Grab keyboard only while the window is focused [env: ELEPHANTINE_NO_LOCAL_GRAB=] [possible values: true, false]
+  -W, --parent-wid [<WINDOW_ID>]       Parent window ID (for partitioning)
+  -c, --colors [<STRING>]              Custom colors for the dialog
+  -a, --ttyalert [<STRING>]            The alert mode (none, beep, or flash)
+      --command <COMMAND>...           The command to run the dialog. It must print the input to stdout [default: "walker --password"]
+  -h, --help                           Print help
+  -V, --version                        Print version
+```

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,15 +6,57 @@ use std::{fs, path::PathBuf, time::Duration};
 #[allow(clippy::module_name_repetitions)]
 #[derive(ClapSerde, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Config {
+    /// The X display to use for the dialog.
+    #[arg(short = 'D', long, env = "PINENTRY_DISPLAY", value_name = "DISPLAY")]
+    pub display: Option<String>,
+
+    /// The tty terminal node name
+    #[arg(short = 'T', long, env = "TTYNAME", value_name = "FILE")]
+    pub ttyname: Option<String>,
+
+    // The tty terminal type
+    #[arg(short = 'N', long, env = "TTYTYPE", value_name = "NAME")]
+    pub ttytype: Option<String>,
+
+    /// The `LC_CTYPE` locale category.
+    #[arg(short = 'C', long, env = "LC_CTYPE", value_name = "STRING")]
+    pub lc_ctype: Option<String>,
+
+    /// The `LC_MESSAGES` value.
+    #[arg(short = 'M', long, env = "LC_MESSAGES", value_name = "STRING")]
+    pub lc_messages: Option<String>,
+
     /// Timeout in seconds for requests that show dialogs to the user.
     /// E.g. GETPIN, CONFIRM, etc.
-    #[arg(short, long, value_name = "TIMEOUT_IN_SECONDS", value_parser = parse_duration, default_value = "300")]
-    pub timeout_in_seconds: Option<Duration>,
+    #[arg(
+        short = 'o',
+        long,
+        env = "ELEPHANTINE_TIMEOUT",
+        value_name = "SECS",
+        value_parser = parse_duration,
+        default_value = "300",
+    )]
+    pub timeout: Option<Duration>,
 
-    /// The command to run when a user input is required.
+    /// Grab keyboard only while the window is focused.
+    #[arg(short = 'g', long, env = "ELEPHANTINE_NO_LOCAL_GRAB")]
+    pub no_local_grab: bool,
+
+    /// Parent window ID (for partitioning).
+    #[arg(short = 'W', long, value_name = "WINDOW_ID")]
+    pub parent_wid: Option<String>,
+
+    /// Custom colors for the dialog.
+    #[arg(short = 'c', long, value_name = "STRING")]
+    pub colors: Option<String>,
+
+    /// The alert mode (none, beep, or flash).
+    #[arg(short = 'a', long, value_name = "STRING")]
+    pub ttyalert: Option<String>,
+
+    /// The command to run the dialog.
     /// It must print the input to stdout.
     #[arg(
-        short,
         long,
         value_name = "COMMAND",
         value_delimiter = ' ',

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ mod test {
 
         let mut output = std::io::Cursor::new(vec![]);
         let mut listener = Listener::new(Config {
-            timeout_in_seconds: None,
+            timeout: None,
             command: vec!["echo", "-n", "1234"]
                 .into_iter()
                 .map(std::string::ToString::to_string)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ mod test {
                 .into_iter()
                 .map(std::string::ToString::to_string)
                 .collect(),
+            ..Default::default()
         });
 
         listener.listen(input, &mut output).unwrap();


### PR DESCRIPTION
Otherwise the CLI arg parser will print the help message and exit.
when it encounters an unknown option.